### PR TITLE
Url fix for microsoft

### DIFF
--- a/data/apps/microsoft.toml
+++ b/data/apps/microsoft.toml
@@ -1,5 +1,5 @@
 name="Microsoft"
-appsURL="https://account.microsoft.com/privacy/"
+appsURL="https://account.live.com/consent/Manage?mkt=en-US&client_flight=m365.suiteheader"
 devicesURL="https://account.microsoft.com/devices/"
 backgroundColor="#71A206"
 foregroundColor="#ffffff"


### PR DESCRIPTION
For Microsoft site, the old 'appsURL' was pointing to the general setting page, instead of the 'Apps Connected' hence updated to the new one